### PR TITLE
[feat] 앱 세로 고정 (#25)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,6 @@ plugins {
     alias(libs.plugins.firebase.crashlytics) apply false
     alias(libs.plugins.ksp) apply false
     alias(libs.plugins.ktlint) apply false
-    alias(libs.plugins.android.library) apply false
 }
 
 allprojects {

--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -1,9 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:ignore="DiscouragedApi">
+
     <application>
         <activity
             android:name=".MainActivity"
             android:exported="true"
+            android:screenOrientation="portrait"
             android:theme="@style/Theme.Ziine">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION
### 📌 관련 이슈

- closed #25

### 📁 작업 설명

- 세로 모드 고정

### 📸 작업화면(선택)
MainActivity에 적용
이후 추가되는 Activity 의 Manifest 에도 같은 작업을 적용해줘야 함

### 비고
이슈에서 언급한 warning 을 직접적으로 해결한 것은 아니기에(tools:ignore 를 통해 무시) 권장되는 방식은 아님 
현재는 가로모드 대응이 권장정도의 수준이지만, 이후 Android 16 버전에 가로모드 반응형 대응이 의무가 될 것이라는 예상이 있음
https://android-developers.googleblog.com/2025/01/orientation-and-resizability-changes-in-android-16.html
기능 작업 완료 후 가로모드 대응을 지원하면 좋을 듯함