### PR TITLE
[feat] 작품 목록, 상세 화면 API 연동 #33

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.Ziine"
+        android:usesCleartextTraffic="true"
         tools:targetApi="31">
 
         <provider

--- a/data/src/main/kotlin/com/nexters/ziine/android/data/di/RetrofitModule.kt
+++ b/data/src/main/kotlin/com/nexters/ziine/android/data/di/RetrofitModule.kt
@@ -18,6 +18,13 @@ import javax.inject.Singleton
 @Module
 @InstallIn(SingletonComponent::class)
 object RetrofitModule {
+    private val jsonRule = Json {
+        encodeDefaults = true
+        ignoreUnknownKeys = true
+        prettyPrint = true
+        isLenient = true
+    }
+
     @Provides
     fun providesHttpLoggingInterceptor(): HttpLoggingInterceptor = HttpLoggingInterceptor().apply { level = HttpLoggingInterceptor.Level.BODY }
 
@@ -48,7 +55,7 @@ object RetrofitModule {
         return Retrofit.Builder()
             .baseUrl(BuildConfig.SERVER_BASE_URL)
             .client(okHttpClient)
-            .addConverterFactory(Json.asConverterFactory(contentType))
+            .addConverterFactory(jsonRule.asConverterFactory(contentType))
             .build()
     }
 }

--- a/data/src/main/kotlin/com/nexters/ziine/android/data/di/RetrofitModule.kt
+++ b/data/src/main/kotlin/com/nexters/ziine/android/data/di/RetrofitModule.kt
@@ -15,16 +15,16 @@ import retrofit2.converter.kotlinx.serialization.asConverterFactory
 import java.util.concurrent.TimeUnit
 import javax.inject.Singleton
 
+private val jsonRule = Json {
+    encodeDefaults = true
+    ignoreUnknownKeys = true
+    prettyPrint = true
+    isLenient = true
+}
+
 @Module
 @InstallIn(SingletonComponent::class)
 object RetrofitModule {
-    private val jsonRule = Json {
-        encodeDefaults = true
-        ignoreUnknownKeys = true
-        prettyPrint = true
-        isLenient = true
-    }
-
     @Provides
     fun providesHttpLoggingInterceptor(): HttpLoggingInterceptor = HttpLoggingInterceptor().apply { level = HttpLoggingInterceptor.Level.BODY }
 

--- a/data/src/main/kotlin/com/nexters/ziine/android/data/httpClient/dto/response/ArtworkDetailResponse.kt
+++ b/data/src/main/kotlin/com/nexters/ziine/android/data/httpClient/dto/response/ArtworkDetailResponse.kt
@@ -19,10 +19,10 @@ data class ArtworkDetailResponse(
     val description: String,
     @SerialName("artworkImageUrl")
     val artworkImageUrl: String,
-    @SerialName("artist")
-    val artist: ArtistDetailResponse,
     @SerialName("shareUrl")
     val shareUrl: String,
+    @SerialName("artist")
+    val artist: ArtistDetailResponse,
 )
 
 @Serializable
@@ -33,12 +33,12 @@ data class ArtistDetailResponse(
     val name: String,
     @SerialName("profileImageUrl")
     val profileImageUrl: String,
-    @SerialName("education")
-    val education: List<String>,
-    @SerialName("exhibition")
-    val exhibition: List<ExhibitionResponse>,
-    @SerialName("contact")
-    val contact: List<ContactResponse>,
+    @SerialName("educations")
+    val educations: List<String>,
+    @SerialName("exhibitions")
+    val exhibitions: List<ExhibitionResponse>,
+    @SerialName("contacts")
+    val contacts: List<ContactResponse>,
     @SerialName("email")
     val email: String,
 )

--- a/data/src/main/kotlin/com/nexters/ziine/android/data/httpClient/dto/response/ArtworkResponse.kt
+++ b/data/src/main/kotlin/com/nexters/ziine/android/data/httpClient/dto/response/ArtworkResponse.kt
@@ -4,8 +4,14 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class ArtworkResponse(
+data class ArtworksResponse(
     @SerialName("artworks")
+    val artworks: List<ArtworkResponse>,
+)
+
+@Serializable
+data class ArtworkResponse(
+    @SerialName("id")
     val id: Int,
     @SerialName("title")
     val title: String,

--- a/data/src/main/kotlin/com/nexters/ziine/android/data/mapper/artwork/ArtworkDtoMapper.kt
+++ b/data/src/main/kotlin/com/nexters/ziine/android/data/mapper/artwork/ArtworkDtoMapper.kt
@@ -46,9 +46,9 @@ fun ArtistDetailResponse.toArtistDetail() =
         id = id,
         name = name,
         profileImageUrl = profileImageUrl,
-        education = education,
-        exhibition = exhibition.map { it.toExhibition() },
-        contact = contact.map { it.toContact() },
+        educations = educations,
+        exhibitions = exhibitions.map { it.toExhibition() },
+        contacts = contacts.map { it.toContact() },
         email = email,
     )
 

--- a/data/src/main/kotlin/com/nexters/ziine/android/data/repository/DefaultArtworkRepository.kt
+++ b/data/src/main/kotlin/com/nexters/ziine/android/data/repository/DefaultArtworkRepository.kt
@@ -1,17 +1,12 @@
 package com.nexters.ziine.android.data.repository
 
 import com.nexters.ziine.android.data.httpClient.convertClassifiedResult
-import com.nexters.ziine.android.data.httpClient.dto.response.ArtistDetailResponse
-import com.nexters.ziine.android.data.httpClient.dto.response.ArtistResponse
-import com.nexters.ziine.android.data.httpClient.dto.response.ArtworkDetailResponse
-import com.nexters.ziine.android.data.httpClient.dto.response.ArtworkResponse
-import com.nexters.ziine.android.data.httpClient.dto.response.ContactResponse
-import com.nexters.ziine.android.data.httpClient.dto.response.ExhibitionResponse
 import com.nexters.ziine.android.data.mapper.artwork.toArtwork
 import com.nexters.ziine.android.data.mapper.artwork.toArtworkDetail
 import com.nexters.ziine.android.data.service.ZiineService
 import com.nexters.ziine.android.domain.entity.Artwork
 import com.nexters.ziine.android.domain.entity.ArtworkDetail
+import com.nexters.ziine.android.domain.entity.Artworks
 import com.nexters.ziine.android.domain.repository.ArtworkRepository
 import javax.inject.Inject
 
@@ -20,106 +15,106 @@ class DefaultArtworkRepository
     constructor(
         private val service: ZiineService,
     ) : ArtworkRepository {
-        override suspend fun fetchArtworks(): Result<List<Artwork>> {
+        override suspend fun fetchArtworks(): Result<Artworks> {
             return convertClassifiedResult {
-                // service.fetchArtworks().map { it.toArtwork() }
-                listOf(
-                    ArtworkResponse(
-                        id = 1,
-                        title = "Artwork 1",
-                        artworkImageUrl = "https://placehold.co/600x400/png",
-                        artist = ArtistResponse(
-                            id = 1,
-                            name = "Artist 1",
-                            profileImageUrl = "https://example.com/profile1.png",
-                        ),
-                    ),
-                    ArtworkResponse(
-                        id = 2,
-                        title = "Artwork 2",
-                        artworkImageUrl = "https://placehold.co/400x600/png",
-                        artist = ArtistResponse(
-                            id = 2,
-                            name = "Artist 2",
-                            profileImageUrl = "https://example.com/profile2.png",
-                        ),
-                    ),
-                    ArtworkResponse(
-                        id = 3,
-                        title = "Artwork 3",
-                        artworkImageUrl = "https://placehold.co/500x500/png",
-                        artist = ArtistResponse(
-                            id = 3,
-                            name = "Artist 3",
-                            profileImageUrl = "https://example.com/profile3.png",
-                        ),
-                    ),
-                    ArtworkResponse(
-                        id = 4,
-                        title = "Artwork 4",
-                        artworkImageUrl = "https://placehold.co/300x500/png",
-                        artist = ArtistResponse(
-                            id = 4,
-                            name = "Artist 4",
-                            profileImageUrl = "https://example.com/profile4.png",
-                        ),
-                    ),
-                    ArtworkResponse(
-                        id = 5,
-                        title = "Artwork 5",
-                        artworkImageUrl = "https://placehold.co/500x300/png",
-                        artist = ArtistResponse(
-                            id = 5,
-                            name = "Artist 5",
-                            profileImageUrl = "https://example.com/profile5.png",
-                        ),
-                    ),
-                    ArtworkResponse(
-                        id = 6,
-                        title = "Artwork 6",
-                        artworkImageUrl = "https://placehold.co/400x800/png",
-                        artist = ArtistResponse(
-                            id = 6,
-                            name = "Artist 6",
-                            profileImageUrl = "https://example.com/profile1.png",
-                        ),
-                    ),
-                ).map { it.toArtwork() }
+                service.fetchArtworks().artworks.map { it.toArtwork() }.let { Artworks(it) }
+//                listOf(
+//                    ArtworkResponse(
+//                        id = 1,
+//                        title = "Artwork 1",
+//                        artworkImageUrl = "https://placehold.co/600x400/png",
+//                        artist = ArtistResponse(
+//                            id = 1,
+//                            name = "Artist 1",
+//                            profileImageUrl = "https://example.com/profile1.png",
+//                        ),
+//                    ),
+//                    ArtworkResponse(
+//                        id = 2,
+//                        title = "Artwork 2",
+//                        artworkImageUrl = "https://placehold.co/400x600/png",
+//                        artist = ArtistResponse(
+//                            id = 2,
+//                            name = "Artist 2",
+//                            profileImageUrl = "https://example.com/profile2.png",
+//                        ),
+//                    ),
+//                    ArtworkResponse(
+//                        id = 3,
+//                        title = "Artwork 3",
+//                        artworkImageUrl = "https://placehold.co/500x500/png",
+//                        artist = ArtistResponse(
+//                            id = 3,
+//                            name = "Artist 3",
+//                            profileImageUrl = "https://example.com/profile3.png",
+//                        ),
+//                    ),
+//                    ArtworkResponse(
+//                        id = 4,
+//                        title = "Artwork 4",
+//                        artworkImageUrl = "https://placehold.co/300x500/png",
+//                        artist = ArtistResponse(
+//                            id = 4,
+//                            name = "Artist 4",
+//                            profileImageUrl = "https://example.com/profile4.png",
+//                        ),
+//                    ),
+//                    ArtworkResponse(
+//                        id = 5,
+//                        title = "Artwork 5",
+//                        artworkImageUrl = "https://placehold.co/500x300/png",
+//                        artist = ArtistResponse(
+//                            id = 5,
+//                            name = "Artist 5",
+//                            profileImageUrl = "https://example.com/profile5.png",
+//                        ),
+//                    ),
+//                    ArtworkResponse(
+//                        id = 6,
+//                        title = "Artwork 6",
+//                        artworkImageUrl = "https://placehold.co/400x800/png",
+//                        artist = ArtistResponse(
+//                            id = 6,
+//                            name = "Artist 6",
+//                            profileImageUrl = "https://example.com/profile1.png",
+//                        ),
+//                    ),
+//                ).map { it.toArtwork() }
             }
         }
 
         override suspend fun fetchArtworkDetail(id: Int): Result<ArtworkDetail> {
             return convertClassifiedResult {
-                // service.fetchArtworkDetail(id).toArtworkDetail()
-                ArtworkDetailResponse(
-                    id = id,
-                    title = "",
-                    width = 100,
-                    height = 100,
-                    material = "페인트",
-                    description = "진짜 진짜 열심히 그림(진짜임)",
-                    artworkImageUrl = "",
-                    artist = ArtistDetailResponse(
-                        id = 1,
-                        name = "멧돼지",
-                        profileImageUrl = "https://example.com/profile1/png",
-                        education = listOf("세종대학교", "동양학과"),
-                        exhibition = listOf(
-                            ExhibitionResponse(
-                                title = "세종대학교 졸업전시회",
-                                exhibitionDate = "2025.02.01",
-                            ),
-                        ),
-                        contact = listOf(
-                            ContactResponse(
-                                type = "INSTAGRAM",
-                                value = "y_joo_z",
-                            ),
-                        ),
-                        email = "yjoo@ziine.com",
-                    ),
-                    shareUrl = "https://m.naver.com",
-                ).toArtworkDetail()
+                service.fetchArtworkDetail(id).toArtworkDetail()
+//                ArtworkDetailResponse(
+//                    id = id,
+//                    title = "",
+//                    width = 100,
+//                    height = 100,
+//                    material = "페인트",
+//                    description = "진짜 진짜 열심히 그림(진짜임)",
+//                    artworkImageUrl = "",
+//                    artist = ArtistDetailResponse(
+//                        id = 1,
+//                        name = "멧돼지",
+//                        profileImageUrl = "https://example.com/profile1/png",
+//                        education = listOf("세종대학교", "동양학과"),
+//                        exhibition = listOf(
+//                            ExhibitionResponse(
+//                                title = "세종대학교 졸업전시회",
+//                                exhibitionDate = "2025.02.01",
+//                            ),
+//                        ),
+//                        contact = listOf(
+//                            ContactResponse(
+//                                type = "INSTAGRAM",
+//                                value = "y_joo_z",
+//                            ),
+//                        ),
+//                        email = "yjoo@ziine.com",
+//                    ),
+//                    shareUrl = "https://m.naver.com",
+//                ).toArtworkDetail()
             }
         }
     }

--- a/data/src/main/kotlin/com/nexters/ziine/android/data/repository/DefaultArtworkRepository.kt
+++ b/data/src/main/kotlin/com/nexters/ziine/android/data/repository/DefaultArtworkRepository.kt
@@ -4,7 +4,6 @@ import com.nexters.ziine.android.data.httpClient.convertClassifiedResult
 import com.nexters.ziine.android.data.mapper.artwork.toArtwork
 import com.nexters.ziine.android.data.mapper.artwork.toArtworkDetail
 import com.nexters.ziine.android.data.service.ZiineService
-import com.nexters.ziine.android.domain.entity.Artwork
 import com.nexters.ziine.android.domain.entity.ArtworkDetail
 import com.nexters.ziine.android.domain.entity.Artworks
 import com.nexters.ziine.android.domain.repository.ArtworkRepository

--- a/data/src/main/kotlin/com/nexters/ziine/android/data/service/ZiineService.kt
+++ b/data/src/main/kotlin/com/nexters/ziine/android/data/service/ZiineService.kt
@@ -3,7 +3,7 @@ package com.nexters.ziine.android.data.service
 import com.nexters.ziine.android.data.httpClient.dto.response.ArtworkDetailResponse
 import com.nexters.ziine.android.data.httpClient.dto.response.ArtworksResponse
 import retrofit2.http.GET
-import retrofit2.http.Query
+import retrofit2.http.Path
 
 interface ZiineService {
     @GET("/api/v1/artworks")
@@ -11,6 +11,6 @@ interface ZiineService {
 
     @GET("/api/v1/artworks/{artwork_id}")
     suspend fun fetchArtworkDetail(
-        @Query("artwork_id}") artworkId: Int,
+        @Path("artwork_id") artworkId: Int,
     ): ArtworkDetailResponse
 }

--- a/data/src/main/kotlin/com/nexters/ziine/android/data/service/ZiineService.kt
+++ b/data/src/main/kotlin/com/nexters/ziine/android/data/service/ZiineService.kt
@@ -1,13 +1,13 @@
 package com.nexters.ziine.android.data.service
 
 import com.nexters.ziine.android.data.httpClient.dto.response.ArtworkDetailResponse
-import com.nexters.ziine.android.data.httpClient.dto.response.ArtworkResponse
+import com.nexters.ziine.android.data.httpClient.dto.response.ArtworksResponse
 import retrofit2.http.GET
 import retrofit2.http.Query
 
 interface ZiineService {
     @GET("/api/v1/artworks")
-    suspend fun fetchArtworks(): List<ArtworkResponse>
+    suspend fun fetchArtworks(): ArtworksResponse
 
     @GET("/api/v1/artworks/{artwork_id}")
     suspend fun fetchArtworkDetail(

--- a/domain/src/main/kotlin/com/nexters/ziine/android/domain/entity/Artwork.kt
+++ b/domain/src/main/kotlin/com/nexters/ziine/android/domain/entity/Artwork.kt
@@ -1,5 +1,9 @@
 package com.nexters.ziine.android.domain.entity
 
+data class Artworks(
+    val artworks: List<Artwork>,
+)
+
 data class Artwork(
     val id: Int,
     val title: String,

--- a/domain/src/main/kotlin/com/nexters/ziine/android/domain/entity/ArtworkDetail.kt
+++ b/domain/src/main/kotlin/com/nexters/ziine/android/domain/entity/ArtworkDetail.kt
@@ -8,17 +8,17 @@ data class ArtworkDetail(
     val material: String,
     val description: String,
     val artworkImageUrl: String,
-    val artist: ArtistDetail,
     val shareUrl: String,
+    val artist: ArtistDetail,
 )
 
 data class ArtistDetail(
     val id: Int,
     val name: String,
     val profileImageUrl: String,
-    val education: List<String>,
-    val exhibition: List<Exhibition>,
-    val contact: List<Contact>,
+    val educations: List<String>,
+    val exhibitions: List<Exhibition>,
+    val contacts: List<Contact>,
     val email: String,
 )
 

--- a/domain/src/main/kotlin/com/nexters/ziine/android/domain/repository/ArtworkRepository.kt
+++ b/domain/src/main/kotlin/com/nexters/ziine/android/domain/repository/ArtworkRepository.kt
@@ -1,10 +1,10 @@
 package com.nexters.ziine.android.domain.repository
 
-import com.nexters.ziine.android.domain.entity.Artwork
 import com.nexters.ziine.android.domain.entity.ArtworkDetail
+import com.nexters.ziine.android.domain.entity.Artworks
 
 interface ArtworkRepository {
-    suspend fun fetchArtworks(): Result<List<Artwork>>
+    suspend fun fetchArtworks(): Result<Artworks>
 
     suspend fun fetchArtworkDetail(id: Int): Result<ArtworkDetail>
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -124,6 +124,13 @@ compose = [
     "androidx-material3",
 ]
 
+landscapist = [
+    "landscapist-bom",
+    "landscapist-coil",
+    "landscapist-placeholder",
+    "landscapist-animation",
+]
+
 [plugins]
 
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -61,10 +61,7 @@ dependencies {
     ksp(libs.hilt.compiler)
 
     implementation(libs.coil.compose)
-    implementation(libs.landscapist.bom)
-    implementation(libs.landscapist.coil)
-    implementation(libs.landscapist.placeholder)
-    implementation(libs.landscapist.animation)
+    implementation(libs.bundles.landscapist)
 
     implementation(libs.compose.system.ui.controller)
     implementation(libs.lottie.compose)

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -65,4 +65,6 @@ dependencies {
 
     implementation(libs.compose.system.ui.controller)
     implementation(libs.lottie.compose)
+
+    implementation(libs.timber)
 }

--- a/presentation/src/main/kotlin/com/nexters/ziine/android/presentation/artworkdetail/ArtworkDetailScreen.kt
+++ b/presentation/src/main/kotlin/com/nexters/ziine/android/presentation/artworkdetail/ArtworkDetailScreen.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.nexters.ziine.android.presentation.LocalSharedTransitionScope
+import com.nexters.ziine.android.presentation.R
 import com.nexters.ziine.android.presentation.artworkdetail.component.ArtistDescription
 import com.nexters.ziine.android.presentation.artworkdetail.component.ArtworkDescription
 import com.nexters.ziine.android.presentation.artworkdetail.component.ArtworkDetailItem
@@ -50,6 +51,7 @@ import com.nexters.ziine.android.presentation.artworkdetail.viewmodel.ArtworkDet
 import com.nexters.ziine.android.presentation.artworkdetail.viewmodel.ArtworkDetailUiState
 import com.nexters.ziine.android.presentation.artworkdetail.viewmodel.ArtworkDetailViewModel
 import com.nexters.ziine.android.presentation.common.util.ObserveAsEvents
+import com.nexters.ziine.android.presentation.component.ZiineErrorDialog
 import com.nexters.ziine.android.presentation.component.ZiineSnackbar
 import com.nexters.ziine.android.presentation.preview.ArtworkDetailPreviewParameterProvider
 import com.nexters.ziine.android.presentation.preview.DevicePreview
@@ -219,6 +221,14 @@ internal fun ArtworkDetailScreen(
             modifier = Modifier.align(Alignment.BottomCenter),
             hostState = snackbarHostState,
             snackbar = { ZiineSnackbar(message = it.visuals.message) },
+        )
+
+        ZiineErrorDialog(
+            isErrorDialogVisible = uiState.isError,
+            onDismissRequest = {},
+            titleResId = R.string.error_title,
+            descriptionResId = R.string.error_description,
+            onRetryClick = { onAction(ArtworkDetailUiAction.OnRetryClick) },
         )
     }
 }

--- a/presentation/src/main/kotlin/com/nexters/ziine/android/presentation/artworkdetail/component/ArtistDescription.kt
+++ b/presentation/src/main/kotlin/com/nexters/ziine/android/presentation/artworkdetail/component/ArtistDescription.kt
@@ -70,7 +70,7 @@ internal fun ArtistDescription(
             )
         }
         Spacer(modifier = Modifier.height(16.dp))
-        EducationTags(educations = uiState.artworkDetail.artist.education)
+        EducationTags(educations = uiState.artworkDetail.artist.educations)
         Spacer(modifier = Modifier.height(40.dp))
         Row(modifier = Modifier.fillMaxWidth()) {
             Text(
@@ -80,7 +80,7 @@ internal fun ArtistDescription(
             )
         }
         Spacer(modifier = Modifier.height(16.dp))
-        ExhibitionRecords(exhibitionRecords = uiState.artworkDetail.artist.exhibition)
+        ExhibitionRecords(exhibitionRecords = uiState.artworkDetail.artist.exhibitions)
         Spacer(modifier = Modifier.height(40.dp))
         Text(
             text = stringResource(R.string.more_work_activities),
@@ -89,7 +89,7 @@ internal fun ArtistDescription(
         )
         Spacer(modifier = Modifier.height(40.dp))
         ContactLinks(
-            contacts = uiState.artworkDetail.artist.contact,
+            contacts = uiState.artworkDetail.artist.contacts,
             onCopyClick = onCopyClick,
         )
     }
@@ -106,8 +106,8 @@ private fun ArtistDescriptionPreview() {
                         id = 0,
                         name = "작가명",
                         profileImageUrl = "",
-                        education = persistentListOf("이화여자대학교", "서양학과"),
-                        exhibition = persistentListOf(
+                        educations = persistentListOf("이화여자대학교", "서양학과"),
+                        exhibitions = persistentListOf(
                             UiExhibition(
                                 title = "서울 OO갤러리 개인전",
                                 exhibitionDate = "2022.11.30",
@@ -121,7 +121,7 @@ private fun ArtistDescriptionPreview() {
                                 exhibitionDate = "2022.11.30",
                             ),
                         ),
-                        contact = persistentListOf(
+                        contacts = persistentListOf(
                             UiContact(
                                 type = "INSTAGRAM",
                                 value = "인스타그램 아이디",

--- a/presentation/src/main/kotlin/com/nexters/ziine/android/presentation/artworkdetail/component/ArtworkDescription.kt
+++ b/presentation/src/main/kotlin/com/nexters/ziine/android/presentation/artworkdetail/component/ArtworkDescription.kt
@@ -79,7 +79,7 @@ internal fun ArtworkDescription(
                 )
                 Spacer(modifier = Modifier.width(16.dp))
                 IconButton(
-                    onClick = { onShareClick(uiState.url) },
+                    onClick = { onShareClick(uiState.artworkDetail.shareUrl) },
                     modifier = Modifier.then(Modifier.size(32.dp))
                 ) {
                     Icon(

--- a/presentation/src/main/kotlin/com/nexters/ziine/android/presentation/artworkdetail/model/UiArtworkDetail.kt
+++ b/presentation/src/main/kotlin/com/nexters/ziine/android/presentation/artworkdetail/model/UiArtworkDetail.kt
@@ -11,17 +11,17 @@ data class UiArtworkDetail(
     val material: String = "",
     val description: String = "",
     val artworkImageUrl: String = "",
-    val artist: UiArtistDetail = UiArtistDetail(),
     val shareUrl: String = "",
+    val artist: UiArtistDetail = UiArtistDetail(),
 )
 
 data class UiArtistDetail(
     val id: Int = 0,
     val name: String = "",
     val profileImageUrl: String = "",
-    val education: ImmutableList<String> = persistentListOf(),
-    val exhibition: ImmutableList<UiExhibition> = persistentListOf(),
-    val contact: ImmutableList<UiContact> = persistentListOf(),
+    val educations: ImmutableList<String> = persistentListOf(),
+    val exhibitions: ImmutableList<UiExhibition> = persistentListOf(),
+    val contacts: ImmutableList<UiContact> = persistentListOf(),
     val email: String = "",
 )
 

--- a/presentation/src/main/kotlin/com/nexters/ziine/android/presentation/artworkdetail/viewmodel/ArtworkDetailUiAction.kt
+++ b/presentation/src/main/kotlin/com/nexters/ziine/android/presentation/artworkdetail/viewmodel/ArtworkDetailUiAction.kt
@@ -9,4 +9,6 @@ sealed interface ArtworkDetailUiAction {
         val type: String,
         val value: String,
     ) : ArtworkDetailUiAction
+
+    data object OnRetryClick : ArtworkDetailUiAction
 }

--- a/presentation/src/main/kotlin/com/nexters/ziine/android/presentation/artworkdetail/viewmodel/ArtworkDetailUiState.kt
+++ b/presentation/src/main/kotlin/com/nexters/ziine/android/presentation/artworkdetail/viewmodel/ArtworkDetailUiState.kt
@@ -5,5 +5,5 @@ import com.nexters.ziine.android.presentation.artworkdetail.model.UiArtworkDetai
 data class ArtworkDetailUiState(
     val isLoading: Boolean = false,
     val artworkDetail: UiArtworkDetail = UiArtworkDetail(),
-    val url: String = "",
+    val isError: Boolean = false,
 )

--- a/presentation/src/main/kotlin/com/nexters/ziine/android/presentation/artworkdetail/viewmodel/ArtworkDetailViewModel.kt
+++ b/presentation/src/main/kotlin/com/nexters/ziine/android/presentation/artworkdetail/viewmodel/ArtworkDetailViewModel.kt
@@ -87,8 +87,8 @@ class ArtworkDetailViewModel
                                         }.toImmutableList(),
                                         email = uiArtworkDetail.artist.email,
                                     ),
+                                    shareUrl = uiArtworkDetail.shareUrl,
                                 ),
-                                url = "https://m.naver.com",
                             )
                         }
                     }.onFailure {

--- a/presentation/src/main/kotlin/com/nexters/ziine/android/presentation/artworkdetail/viewmodel/ArtworkDetailViewModel.kt
+++ b/presentation/src/main/kotlin/com/nexters/ziine/android/presentation/artworkdetail/viewmodel/ArtworkDetailViewModel.kt
@@ -24,95 +24,97 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class ArtworkDetailViewModel @Inject constructor(
-    private val artworkRepository: ArtworkRepository,
-    savedStateHandle: SavedStateHandle,
-) : ViewModel() {
-    private val id = savedStateHandle.toRoute<Route.ArtworkDetail>().id
-    private val title = savedStateHandle.toRoute<Route.ArtworkDetail>().title
-    private val artworkImageUrl = savedStateHandle.toRoute<Route.ArtworkDetail>().artworkImageUrl
+class ArtworkDetailViewModel
+    @Inject
+    constructor(
+        private val artworkRepository: ArtworkRepository,
+        savedStateHandle: SavedStateHandle,
+    ) : ViewModel() {
+        private val id = savedStateHandle.toRoute<Route.ArtworkDetail>().id
+        private val title = savedStateHandle.toRoute<Route.ArtworkDetail>().title
+        private val artworkImageUrl = savedStateHandle.toRoute<Route.ArtworkDetail>().artworkImageUrl
 
-    private val _uiState = MutableStateFlow(ArtworkDetailUiState())
-    val uiState: StateFlow<ArtworkDetailUiState> = _uiState.asStateFlow()
+        private val _uiState = MutableStateFlow(ArtworkDetailUiState())
+        val uiState: StateFlow<ArtworkDetailUiState> = _uiState.asStateFlow()
 
-    private val _uiEvent = Channel<ArtworkDetailUiEvent>()
-    val uiEvent: Flow<ArtworkDetailUiEvent> = _uiEvent.receiveAsFlow()
+        private val _uiEvent = Channel<ArtworkDetailUiEvent>()
+        val uiEvent: Flow<ArtworkDetailUiEvent> = _uiEvent.receiveAsFlow()
 
-    init {
-        fetchArtworkDetail(id)
-    }
-
-    fun onAction(action: ArtworkDetailUiAction) {
-        when (action) {
-            is ArtworkDetailUiAction.OnBackClick -> navigateBack()
-            is ArtworkDetailUiAction.OnShareClick -> shareUrl(action.url)
-            is ArtworkDetailUiAction.OnCopyClick -> copyValue(action.type, action.value)
+        init {
+            fetchArtworkDetail(id)
         }
-    }
 
-    private fun fetchArtworkDetail(id: Int) {
-        viewModelScope.launch {
-            _uiState.update { it.copy(isLoading = true) }
-            artworkRepository.fetchArtworkDetail(id)
-                .onSuccess { result ->
-                    val uiArtworkDetail = result.toUiArtworkDetail()
-                    _uiState.update {
-                        it.copy(
-                            artworkDetail = UiArtworkDetail(
-                                id = id,
-                                title = title,
-                                width = uiArtworkDetail.width,
-                                height = uiArtworkDetail.height,
-                                material = uiArtworkDetail.material,
-                                description = uiArtworkDetail.description,
-                                artworkImageUrl = artworkImageUrl,
-                                artist = UiArtistDetail(
-                                    id = uiArtworkDetail.artist.id,
-                                    name = uiArtworkDetail.artist.name,
-                                    profileImageUrl = uiArtworkDetail.artist.profileImageUrl,
-                                    education = uiArtworkDetail.artist.education.toImmutableList(),
-                                    exhibition = uiArtworkDetail.artist.exhibition.map { exhibition ->
-                                        UiExhibition(
-                                            title = exhibition.title,
-                                            exhibitionDate = exhibition.exhibitionDate,
-                                        )
-                                    }.toImmutableList(),
-                                    contact = uiArtworkDetail.artist.contact.map { contact ->
-                                        UiContact(
-                                            type = contact.type,
-                                            value = contact.value,
-                                        )
-                                    }.toImmutableList(),
-                                    email = uiArtworkDetail.artist.email,
+        fun onAction(action: ArtworkDetailUiAction) {
+            when (action) {
+                is ArtworkDetailUiAction.OnBackClick -> navigateBack()
+                is ArtworkDetailUiAction.OnShareClick -> shareUrl(action.url)
+                is ArtworkDetailUiAction.OnCopyClick -> copyValue(action.type, action.value)
+            }
+        }
+
+        private fun fetchArtworkDetail(id: Int) {
+            viewModelScope.launch {
+                _uiState.update { it.copy(isLoading = true) }
+                artworkRepository.fetchArtworkDetail(id)
+                    .onSuccess { result ->
+                        val uiArtworkDetail = result.toUiArtworkDetail()
+                        _uiState.update {
+                            it.copy(
+                                artworkDetail = UiArtworkDetail(
+                                    id = id,
+                                    title = title,
+                                    width = uiArtworkDetail.width,
+                                    height = uiArtworkDetail.height,
+                                    material = uiArtworkDetail.material,
+                                    description = uiArtworkDetail.description,
+                                    artworkImageUrl = artworkImageUrl,
+                                    artist = UiArtistDetail(
+                                        id = uiArtworkDetail.artist.id,
+                                        name = uiArtworkDetail.artist.name,
+                                        profileImageUrl = uiArtworkDetail.artist.profileImageUrl,
+                                        education = uiArtworkDetail.artist.education.toImmutableList(),
+                                        exhibition = uiArtworkDetail.artist.exhibition.map { exhibition ->
+                                            UiExhibition(
+                                                title = exhibition.title,
+                                                exhibitionDate = exhibition.exhibitionDate,
+                                            )
+                                        }.toImmutableList(),
+                                        contact = uiArtworkDetail.artist.contact.map { contact ->
+                                            UiContact(
+                                                type = contact.type,
+                                                value = contact.value,
+                                            )
+                                        }.toImmutableList(),
+                                        email = uiArtworkDetail.artist.email,
+                                    ),
                                 ),
-                            ),
-                            url = "https://m.naver.com",
-                        )
+                                url = "https://m.naver.com",
+                            )
+                        }
+                    }.onFailure {
                     }
-                }.onFailure {
-                }
-            _uiState.update { it.copy(isLoading = false) }
+                _uiState.update { it.copy(isLoading = false) }
+            }
         }
-    }
 
-    private fun navigateBack() {
-        viewModelScope.launch {
-            _uiEvent.send(ArtworkDetailUiEvent.NavigateBack)
+        private fun navigateBack() {
+            viewModelScope.launch {
+                _uiEvent.send(ArtworkDetailUiEvent.NavigateBack)
+            }
         }
-    }
 
-    private fun shareUrl(url: String) {
-        viewModelScope.launch {
-            _uiEvent.send(ArtworkDetailUiEvent.ShareUrl(url))
+        private fun shareUrl(url: String) {
+            viewModelScope.launch {
+                _uiEvent.send(ArtworkDetailUiEvent.ShareUrl(url))
+            }
         }
-    }
 
-    private fun copyValue(
-        type: String,
-        value: String,
-    ) {
-        viewModelScope.launch {
-            _uiEvent.send(ArtworkDetailUiEvent.CopyValue(type, value))
+        private fun copyValue(
+            type: String,
+            value: String,
+        ) {
+            viewModelScope.launch {
+                _uiEvent.send(ArtworkDetailUiEvent.CopyValue(type, value))
+            }
         }
     }
-}

--- a/presentation/src/main/kotlin/com/nexters/ziine/android/presentation/artworkdetail/viewmodel/ArtworkDetailViewModel.kt
+++ b/presentation/src/main/kotlin/com/nexters/ziine/android/presentation/artworkdetail/viewmodel/ArtworkDetailViewModel.kt
@@ -71,16 +71,16 @@ class ArtworkDetailViewModel @Inject constructor(
                                     name = uiArtworkDetail.artist.name,
                                     profileImageUrl = uiArtworkDetail.artist.profileImageUrl,
                                     education = uiArtworkDetail.artist.education.toImmutableList(),
-                                    exhibition = uiArtworkDetail.artist.exhibition.map {
+                                    exhibition = uiArtworkDetail.artist.exhibition.map { exhibition ->
                                         UiExhibition(
-                                            title = it.title,
-                                            exhibitionDate = it.exhibitionDate,
+                                            title = exhibition.title,
+                                            exhibitionDate = exhibition.exhibitionDate,
                                         )
                                     }.toImmutableList(),
-                                    contact = uiArtworkDetail.artist.contact.map {
+                                    contact = uiArtworkDetail.artist.contact.map { contact ->
                                         UiContact(
-                                            type = it.type,
-                                            value = it.value,
+                                            type = contact.type,
+                                            value = contact.value,
                                         )
                                     }.toImmutableList(),
                                     email = uiArtworkDetail.artist.email,

--- a/presentation/src/main/kotlin/com/nexters/ziine/android/presentation/artworkdetail/viewmodel/ArtworkDetailViewModel.kt
+++ b/presentation/src/main/kotlin/com/nexters/ziine/android/presentation/artworkdetail/viewmodel/ArtworkDetailViewModel.kt
@@ -72,14 +72,14 @@ class ArtworkDetailViewModel
                                         id = uiArtworkDetail.artist.id,
                                         name = uiArtworkDetail.artist.name,
                                         profileImageUrl = uiArtworkDetail.artist.profileImageUrl,
-                                        education = uiArtworkDetail.artist.education.toImmutableList(),
-                                        exhibition = uiArtworkDetail.artist.exhibition.map { exhibition ->
+                                        educations = uiArtworkDetail.artist.educations.toImmutableList(),
+                                        exhibitions = uiArtworkDetail.artist.exhibitions.map { exhibition ->
                                             UiExhibition(
                                                 title = exhibition.title,
                                                 exhibitionDate = exhibition.exhibitionDate,
                                             )
                                         }.toImmutableList(),
-                                        contact = uiArtworkDetail.artist.contact.map { contact ->
+                                        contacts = uiArtworkDetail.artist.contacts.map { contact ->
                                             UiContact(
                                                 type = contact.type,
                                                 value = contact.value,
@@ -92,6 +92,9 @@ class ArtworkDetailViewModel
                             )
                         }
                     }.onFailure {
+                        _uiState.update {
+                            it.copy(isError = true)
+                        }
                     }
                 _uiState.update { it.copy(isLoading = false) }
             }

--- a/presentation/src/main/kotlin/com/nexters/ziine/android/presentation/artworkdetail/viewmodel/ArtworkDetailViewModel.kt
+++ b/presentation/src/main/kotlin/com/nexters/ziine/android/presentation/artworkdetail/viewmodel/ArtworkDetailViewModel.kt
@@ -49,6 +49,7 @@ class ArtworkDetailViewModel
                 is ArtworkDetailUiAction.OnBackClick -> navigateBack()
                 is ArtworkDetailUiAction.OnShareClick -> shareUrl(action.url)
                 is ArtworkDetailUiAction.OnCopyClick -> copyValue(action.type, action.value)
+                is ArtworkDetailUiAction.OnRetryClick -> fetchArtworkDetail(id)
             }
         }
 
@@ -89,6 +90,7 @@ class ArtworkDetailViewModel
                                     ),
                                     shareUrl = uiArtworkDetail.shareUrl,
                                 ),
+                                isError = false,
                             )
                         }
                     }.onFailure {

--- a/presentation/src/main/kotlin/com/nexters/ziine/android/presentation/artworks/ArtworksScreen.kt
+++ b/presentation/src/main/kotlin/com/nexters/ziine/android/presentation/artworks/ArtworksScreen.kt
@@ -27,12 +27,14 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.nexters.ziine.android.presentation.LocalSharedTransitionScope
+import com.nexters.ziine.android.presentation.R
 import com.nexters.ziine.android.presentation.artworks.viewmodel.ArtworksUiAction
 import com.nexters.ziine.android.presentation.artworks.viewmodel.ArtworksUiEvent
 import com.nexters.ziine.android.presentation.artworks.viewmodel.ArtworksUiState
 import com.nexters.ziine.android.presentation.artworks.viewmodel.ArtworksViewModel
 import com.nexters.ziine.android.presentation.common.util.ObserveAsEvents
 import com.nexters.ziine.android.presentation.component.LoadingIndicator
+import com.nexters.ziine.android.presentation.component.ZiineErrorDialog
 import com.nexters.ziine.android.presentation.preview.ArtworksPreviewParameterProvider
 import com.nexters.ziine.android.presentation.preview.DevicePreview
 import com.nexters.ziine.android.presentation.ui.theme.ZiineTheme
@@ -116,6 +118,14 @@ internal fun ArtworksScreen(
         }
 
         LoadingIndicator(isLoading = uiState.isLoading)
+
+        ZiineErrorDialog(
+            isErrorDialogVisible = uiState.isError,
+            onDismissRequest = {},
+            titleResId = R.string.error_title,
+            descriptionResId = R.string.error_description,
+            onRetryClick = { onAction(ArtworksUiAction.OnRetryClick) },
+        )
     }
 }
 

--- a/presentation/src/main/kotlin/com/nexters/ziine/android/presentation/artworks/ArtworksScreen.kt
+++ b/presentation/src/main/kotlin/com/nexters/ziine/android/presentation/artworks/ArtworksScreen.kt
@@ -91,7 +91,7 @@ internal fun ArtworksScreen(
     ) {
         LazyColumn(
             modifier = Modifier.fillMaxSize(),
-            contentPadding = PaddingValues(vertical = 16.dp),
+            contentPadding = PaddingValues(top = 16.dp, bottom = 84.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
             items(

--- a/presentation/src/main/kotlin/com/nexters/ziine/android/presentation/artworks/ArtworksScreen.kt
+++ b/presentation/src/main/kotlin/com/nexters/ziine/android/presentation/artworks/ArtworksScreen.kt
@@ -104,9 +104,9 @@ internal fun ArtworksScreen(
                         vibrator.vibrate(VibrationEffect.createOneShot(50, VibrationEffect.DEFAULT_AMPLITUDE))
                         onAction(
                             ArtworksUiAction.OnArtworkItemSelect(
-                                artwork.id,
-                                artwork.artworkImageUrl,
-                                artwork.title,
+                                id = artwork.id,
+                                title = artwork.title,
+                                artworkImageUrl = artwork.artworkImageUrl,
                             ),
                         )
                     },

--- a/presentation/src/main/kotlin/com/nexters/ziine/android/presentation/artworks/viewmodel/ArtworksUiAction.kt
+++ b/presentation/src/main/kotlin/com/nexters/ziine/android/presentation/artworks/viewmodel/ArtworksUiAction.kt
@@ -6,4 +6,6 @@ sealed interface ArtworksUiAction {
         val title: String,
         val artworkImageUrl: String,
     ) : ArtworksUiAction
+
+    data object OnRetryClick : ArtworksUiAction
 }

--- a/presentation/src/main/kotlin/com/nexters/ziine/android/presentation/artworks/viewmodel/ArtworksUiState.kt
+++ b/presentation/src/main/kotlin/com/nexters/ziine/android/presentation/artworks/viewmodel/ArtworksUiState.kt
@@ -7,4 +7,5 @@ import kotlinx.collections.immutable.persistentListOf
 data class ArtworksUiState(
     val isLoading: Boolean = false,
     val artworks: ImmutableList<UiArtwork> = persistentListOf(),
+    val isError: Boolean = false,
 )

--- a/presentation/src/main/kotlin/com/nexters/ziine/android/presentation/artworks/viewmodel/ArtworksViewModel.kt
+++ b/presentation/src/main/kotlin/com/nexters/ziine/android/presentation/artworks/viewmodel/ArtworksViewModel.kt
@@ -3,7 +3,7 @@ package com.nexters.ziine.android.presentation.artworks.viewmodel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.nexters.ziine.android.domain.repository.ArtworkRepository
-import com.nexters.ziine.android.presentation.mapper.artwork.toUiArtworks
+import com.nexters.ziine.android.presentation.mapper.artwork.toUiArtwork
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.channels.Channel
@@ -43,14 +43,17 @@ class ArtworksViewModel
             fetchArtworks()
         }
 
-        private fun fetchArtworks() {
+        fun fetchArtworks() {
             viewModelScope.launch {
                 _uiState.update { it.copy(isLoading = true) }
-                // delay(1000)
                 artworkRepository.fetchArtworks()
                     .onSuccess { result ->
                         _uiState.update {
-                            it.copy(artworks = result.map { it.toUiArtworks() }.toImmutableList())
+                            it.copy(
+                                artworks = result.artworks.map { artwork ->
+                                    artwork.toUiArtwork()
+                                }.toImmutableList(),
+                            )
                         }
                     }.onFailure { exception ->
                         Timber.d(exception)

--- a/presentation/src/main/kotlin/com/nexters/ziine/android/presentation/artworks/viewmodel/ArtworksViewModel.kt
+++ b/presentation/src/main/kotlin/com/nexters/ziine/android/presentation/artworks/viewmodel/ArtworksViewModel.kt
@@ -19,58 +19,58 @@ import javax.inject.Inject
 
 @HiltViewModel
 class ArtworksViewModel
-@Inject
-constructor(
-    private val artworkRepository: ArtworkRepository,
-) : ViewModel() {
-    private val _uiState = MutableStateFlow(ArtworksUiState())
-    val uiState: StateFlow<ArtworksUiState> = _uiState.asStateFlow()
+    @Inject
+    constructor(
+        private val artworkRepository: ArtworkRepository,
+    ) : ViewModel() {
+        private val _uiState = MutableStateFlow(ArtworksUiState())
+        val uiState: StateFlow<ArtworksUiState> = _uiState.asStateFlow()
 
-    private val _uiEvent = Channel<ArtworksUiEvent>()
-    val uiEvent: Flow<ArtworksUiEvent> = _uiEvent.receiveAsFlow()
+        private val _uiEvent = Channel<ArtworksUiEvent>()
+        val uiEvent: Flow<ArtworksUiEvent> = _uiEvent.receiveAsFlow()
 
-    fun onAction(action: ArtworksUiAction) {
-        when (action) {
-            is ArtworksUiAction.OnArtworkItemSelect -> navigateToArtworkDetail(
-                id = action.id,
-                title = action.title,
-                artworkImageUrl = action.artworkImageUrl,
-            )
+        fun onAction(action: ArtworksUiAction) {
+            when (action) {
+                is ArtworksUiAction.OnArtworkItemSelect -> navigateToArtworkDetail(
+                    id = action.id,
+                    title = action.title,
+                    artworkImageUrl = action.artworkImageUrl,
+                )
+            }
         }
-    }
 
-    init {
-        fetchArtworks()
-    }
+        init {
+            fetchArtworks()
+        }
 
-    private fun fetchArtworks() {
-        viewModelScope.launch {
-            _uiState.update { it.copy(isLoading = true) }
-            delay(1000)
-            artworkRepository.fetchArtworks()
-                .onSuccess { result ->
-                    _uiState.update {
-                        it.copy(artworks = result.map { it.toUiArtworks() }.toImmutableList())
+        private fun fetchArtworks() {
+            viewModelScope.launch {
+                _uiState.update { it.copy(isLoading = true) }
+                delay(1000)
+                artworkRepository.fetchArtworks()
+                    .onSuccess { result ->
+                        _uiState.update {
+                            it.copy(artworks = result.map { it.toUiArtworks() }.toImmutableList())
+                        }
+                    }.onFailure {
                     }
-                }.onFailure {
-                }
-            _uiState.update { it.copy(isLoading = false) }
+                _uiState.update { it.copy(isLoading = false) }
+            }
         }
-    }
 
-    private fun navigateToArtworkDetail(
-        id: Int,
-        title: String,
-        artworkImageUrl: String,
-    ) {
-        viewModelScope.launch {
-            _uiEvent.send(
-                ArtworksUiEvent.NavigateToArtworkDetail(
-                    id = id,
-                    title = title,
-                    artworkImageUrl = artworkImageUrl,
-                ),
-            )
+        private fun navigateToArtworkDetail(
+            id: Int,
+            title: String,
+            artworkImageUrl: String,
+        ) {
+            viewModelScope.launch {
+                _uiEvent.send(
+                    ArtworksUiEvent.NavigateToArtworkDetail(
+                        id = id,
+                        title = title,
+                        artworkImageUrl = artworkImageUrl,
+                    ),
+                )
+            }
         }
     }
-}

--- a/presentation/src/main/kotlin/com/nexters/ziine/android/presentation/artworks/viewmodel/ArtworksViewModel.kt
+++ b/presentation/src/main/kotlin/com/nexters/ziine/android/presentation/artworks/viewmodel/ArtworksViewModel.kt
@@ -7,7 +7,6 @@ import com.nexters.ziine.android.presentation.mapper.artwork.toUiArtworks
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -15,6 +14,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -46,13 +46,17 @@ class ArtworksViewModel
         private fun fetchArtworks() {
             viewModelScope.launch {
                 _uiState.update { it.copy(isLoading = true) }
-                delay(1000)
+                // delay(1000)
                 artworkRepository.fetchArtworks()
                     .onSuccess { result ->
                         _uiState.update {
                             it.copy(artworks = result.map { it.toUiArtworks() }.toImmutableList())
                         }
-                    }.onFailure {
+                    }.onFailure { exception ->
+                        Timber.d(exception)
+                        _uiState.update {
+                            it.copy(isError = true)
+                        }
                     }
                 _uiState.update { it.copy(isLoading = false) }
             }

--- a/presentation/src/main/kotlin/com/nexters/ziine/android/presentation/artworks/viewmodel/ArtworksViewModel.kt
+++ b/presentation/src/main/kotlin/com/nexters/ziine/android/presentation/artworks/viewmodel/ArtworksViewModel.kt
@@ -29,6 +29,10 @@ class ArtworksViewModel
         private val _uiEvent = Channel<ArtworksUiEvent>()
         val uiEvent: Flow<ArtworksUiEvent> = _uiEvent.receiveAsFlow()
 
+        init {
+            fetchArtworks()
+        }
+
         fun onAction(action: ArtworksUiAction) {
             when (action) {
                 is ArtworksUiAction.OnArtworkItemSelect -> navigateToArtworkDetail(
@@ -36,14 +40,12 @@ class ArtworksViewModel
                     title = action.title,
                     artworkImageUrl = action.artworkImageUrl,
                 )
+
+                is ArtworksUiAction.OnRetryClick -> fetchArtworks()
             }
         }
 
-        init {
-            fetchArtworks()
-        }
-
-        fun fetchArtworks() {
+        private fun fetchArtworks() {
             viewModelScope.launch {
                 _uiState.update { it.copy(isLoading = true) }
                 artworkRepository.fetchArtworks()
@@ -53,6 +55,7 @@ class ArtworksViewModel
                                 artworks = result.artworks.map { artwork ->
                                     artwork.toUiArtwork()
                                 }.toImmutableList(),
+                                isError = false,
                             )
                         }
                     }.onFailure { exception ->

--- a/presentation/src/main/kotlin/com/nexters/ziine/android/presentation/component/ZiineErrorDialog.kt
+++ b/presentation/src/main/kotlin/com/nexters/ziine/android/presentation/component/ZiineErrorDialog.kt
@@ -1,6 +1,9 @@
 package com.nexters.ziine.android.presentation.component
 
 import androidx.annotation.StringRes
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -32,6 +35,7 @@ import com.nexters.ziine.android.presentation.ui.theme.ZiineTheme
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ZiineErrorDialog(
+    isErrorDialogVisible: Boolean,
     onDismissRequest: () -> Unit,
     @StringRes titleResId: Int,
     @StringRes descriptionResId: Int,
@@ -39,50 +43,56 @@ fun ZiineErrorDialog(
     modifier: Modifier = Modifier,
     properties: DialogProperties = DialogProperties(usePlatformDefaultWidth = false),
 ) {
-    BasicAlertDialog(
-        onDismissRequest = onDismissRequest,
-        properties = properties,
+    AnimatedVisibility(
+        visible = isErrorDialogVisible,
+        enter = fadeIn(),
+        exit = fadeOut(),
     ) {
-        Column(
-            modifier = modifier
-                .fillMaxSize()
-                .background(color = MaterialTheme.colorScheme.background),
-            horizontalAlignment = Alignment.CenterHorizontally
+        BasicAlertDialog(
+            onDismissRequest = onDismissRequest,
+            properties = properties,
         ) {
-            Spacer(modifier = Modifier.height(60.dp))
-            Text(
-                text = stringResource(id = titleResId),
-                style = Subtitle2,
-                color = MaterialTheme.colorScheme.onBackground,
-            )
-            Spacer(modifier = Modifier.height(12.dp))
-            Text(
-                text = stringResource(id = descriptionResId),
-                style = Subtitle2,
-                color = MaterialTheme.colorScheme.onBackground,
-            )
-            Spacer(modifier = Modifier.height(64.dp))
-            Image(
-                painter = painterResource(id = R.drawable.placeholder),
-                contentDescription = "Error Image",
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 48.dp)
-            )
-            Spacer(modifier = Modifier.height(40.dp))
-            OutlinedButton(
-                onClick = onRetryClick,
-                modifier = Modifier
-                    .height(45.dp)
-                    .padding(horizontal = 24.dp),
-                shape = RoundedCornerShape(6.dp),
-                border = BorderStroke(1.5.dp, MaterialTheme.colorScheme.outline)
+            Column(
+                modifier = modifier
+                    .fillMaxSize()
+                    .background(color = MaterialTheme.colorScheme.background),
+                horizontalAlignment = Alignment.CenterHorizontally,
             ) {
+                Spacer(modifier = Modifier.height(60.dp))
                 Text(
-                    text = stringResource(id = R.string.retry),
+                    text = stringResource(id = titleResId),
+                    style = Subtitle2,
                     color = MaterialTheme.colorScheme.onBackground,
-                    style = Paragraph4
                 )
+                Spacer(modifier = Modifier.height(12.dp))
+                Text(
+                    text = stringResource(id = descriptionResId),
+                    style = Subtitle2,
+                    color = MaterialTheme.colorScheme.onBackground,
+                )
+                Spacer(modifier = Modifier.height(64.dp))
+                Image(
+                    painter = painterResource(id = R.drawable.placeholder),
+                    contentDescription = "Error Image",
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 48.dp),
+                )
+                Spacer(modifier = Modifier.height(40.dp))
+                OutlinedButton(
+                    onClick = onRetryClick,
+                    modifier = Modifier
+                        .height(45.dp)
+                        .padding(horizontal = 24.dp),
+                    shape = RoundedCornerShape(6.dp),
+                    border = BorderStroke(1.5.dp, MaterialTheme.colorScheme.outline),
+                ) {
+                    Text(
+                        text = stringResource(id = R.string.retry),
+                        color = MaterialTheme.colorScheme.onBackground,
+                        style = Paragraph4,
+                    )
+                }
             }
         }
     }
@@ -93,10 +103,11 @@ fun ZiineErrorDialog(
 private fun ZiineErrorDialogPreview() {
     ZiineTheme {
         ZiineErrorDialog(
+            isErrorDialogVisible = true,
             onDismissRequest = { },
             titleResId = R.string.error_title,
             descriptionResId = R.string.error_description,
-            onRetryClick = { }
+            onRetryClick = { },
         )
     }
 }

--- a/presentation/src/main/kotlin/com/nexters/ziine/android/presentation/component/ZiineErrorDialog.kt
+++ b/presentation/src/main/kotlin/com/nexters/ziine/android/presentation/component/ZiineErrorDialog.kt
@@ -1,0 +1,102 @@
+package com.nexters.ziine.android.presentation.component
+
+import androidx.annotation.StringRes
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.BasicAlertDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.DialogProperties
+import com.nexters.ziine.android.presentation.R
+import com.nexters.ziine.android.presentation.preview.ComponentPreview
+import com.nexters.ziine.android.presentation.ui.theme.Paragraph4
+import com.nexters.ziine.android.presentation.ui.theme.Subtitle2
+import com.nexters.ziine.android.presentation.ui.theme.ZiineTheme
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ZiineErrorDialog(
+    onDismissRequest: () -> Unit,
+    @StringRes titleResId: Int,
+    @StringRes descriptionResId: Int,
+    onRetryClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    properties: DialogProperties = DialogProperties(usePlatformDefaultWidth = false),
+) {
+    BasicAlertDialog(
+        onDismissRequest = onDismissRequest,
+        properties = properties,
+    ) {
+        Column(
+            modifier = modifier
+                .fillMaxSize()
+                .background(color = MaterialTheme.colorScheme.background),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Spacer(modifier = Modifier.height(60.dp))
+            Text(
+                text = stringResource(id = titleResId),
+                style = Subtitle2,
+                color = MaterialTheme.colorScheme.onBackground,
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+            Text(
+                text = stringResource(id = descriptionResId),
+                style = Subtitle2,
+                color = MaterialTheme.colorScheme.onBackground,
+            )
+            Spacer(modifier = Modifier.height(64.dp))
+            Image(
+                painter = painterResource(id = R.drawable.placeholder),
+                contentDescription = "Error Image",
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 48.dp)
+            )
+            Spacer(modifier = Modifier.height(40.dp))
+            OutlinedButton(
+                onClick = onRetryClick,
+                modifier = Modifier
+                    .height(45.dp)
+                    .padding(horizontal = 24.dp),
+                shape = RoundedCornerShape(6.dp),
+                border = BorderStroke(1.5.dp, MaterialTheme.colorScheme.outline)
+            ) {
+                Text(
+                    text = stringResource(id = R.string.retry),
+                    color = MaterialTheme.colorScheme.onBackground,
+                    style = Paragraph4
+                )
+            }
+        }
+    }
+}
+
+@ComponentPreview
+@Composable
+private fun ZiineErrorDialogPreview() {
+    ZiineTheme {
+        ZiineErrorDialog(
+            onDismissRequest = { },
+            titleResId = R.string.error_title,
+            descriptionResId = R.string.error_description,
+            onRetryClick = { }
+        )
+    }
+}

--- a/presentation/src/main/kotlin/com/nexters/ziine/android/presentation/mapper/artwork/ArtworkUiMapper.kt
+++ b/presentation/src/main/kotlin/com/nexters/ziine/android/presentation/mapper/artwork/ArtworkUiMapper.kt
@@ -14,7 +14,7 @@ import com.nexters.ziine.android.presentation.artworks.model.UiArtist
 import com.nexters.ziine.android.presentation.artworks.model.UiArtwork
 import kotlinx.collections.immutable.toImmutableList
 
-fun Artwork.toUiArtworks() =
+fun Artwork.toUiArtwork() =
     UiArtwork(
         id = id,
         title = title,

--- a/presentation/src/main/kotlin/com/nexters/ziine/android/presentation/mapper/artwork/ArtworkUiMapper.kt
+++ b/presentation/src/main/kotlin/com/nexters/ziine/android/presentation/mapper/artwork/ArtworkUiMapper.kt
@@ -46,9 +46,9 @@ fun ArtistDetail.toUiArtistDetail() =
         id = id,
         name = name,
         profileImageUrl = profileImageUrl,
-        education = education.toImmutableList(),
-        exhibition = exhibition.map { it.toUiExhibition() }.toImmutableList(),
-        contact = contact.map { it.toUiContact() }.toImmutableList(),
+        educations = educations.toImmutableList(),
+        exhibitions = exhibitions.map { it.toUiExhibition() }.toImmutableList(),
+        contacts = contacts.map { it.toUiContact() }.toImmutableList(),
         email = email,
     )
 

--- a/presentation/src/main/kotlin/com/nexters/ziine/android/presentation/preview/ArtworkDetailPreviewParameterProvider.kt
+++ b/presentation/src/main/kotlin/com/nexters/ziine/android/presentation/preview/ArtworkDetailPreviewParameterProvider.kt
@@ -8,21 +8,21 @@ import com.nexters.ziine.android.presentation.artworkdetail.viewmodel.ArtworkDet
 internal class ArtworkDetailPreviewParameterProvider : PreviewParameterProvider<ArtworkDetailUiState> {
     override val values = sequenceOf(
         ArtworkDetailUiState(
-            artwork = UiArtworkDetail(
+            artworkDetail = UiArtworkDetail(
                 id = 1,
                 title = "Artwork 1",
                 width = 100,
                 height = 100,
                 material = "Material 1",
                 description = "Description 1",
-                imageUrl = "https://placehold.co/600x400/png",
+                artworkImageUrl = "https://placehold.co/600x400/png",
                 artist = UiArtistDetail(
                     id = 1,
                     name = "Artist 1",
                     profileImageUrl = "https://example.com/profile1.png",
                 ),
             ),
-            url = "https://naver.com",
+            url = "https://m.naver.com",
         ),
     )
 }

--- a/presentation/src/main/kotlin/com/nexters/ziine/android/presentation/preview/ArtworkDetailPreviewParameterProvider.kt
+++ b/presentation/src/main/kotlin/com/nexters/ziine/android/presentation/preview/ArtworkDetailPreviewParameterProvider.kt
@@ -21,8 +21,8 @@ internal class ArtworkDetailPreviewParameterProvider : PreviewParameterProvider<
                     name = "Artist 1",
                     profileImageUrl = "https://example.com/profile1.png",
                 ),
+                shareUrl = "https://m.naver.com",
             ),
-            url = "https://m.naver.com",
         ),
     )
 }

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -11,4 +11,7 @@
     <string name="other">OTHER</string>
     <string name="link_has_been_copied">링크가 복사되었습니다.</string>
     <string name="instagram_id_has_been_copied">인스타그램 아이디가 복사되었습니다.</string>
+    <string name="error_title">앗, 오류가 발생했어요.</string>
+    <string name="error_description">다시 시도해주세요.</string>
+    <string name="retry">다시 시도하기</string>
 </resources>


### PR DESCRIPTION
### 📌 관련 이슈

- closed #33

### 📁 작업 설명

- 작품 목록 화면 API 연동
- 작품 상세 화면 API 연동
- RetrofitModule kotlinx serialization JsonRult 설정
- 에러 화면 구성
- 에러 화면 연동 및 다시 시도 처리 구현

### 📸 작업화면(선택)

- 작품 목록 화면, 작품 상세 화면
